### PR TITLE
Proposed changes to predicted_molecular_consequence to handle relative locations

### DIFF
--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -81,7 +81,13 @@
             "transcript_biotype": "protein_coding",
             "cdna_location": 
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
@@ -92,7 +98,13 @@
             },
             "cds_location": 
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 776, 
                 "end": 776, 
                 "length": 1, 
@@ -102,7 +114,13 @@
             },
             "protein_location":
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 259, 
                 "end": 259, 
                 "length": 1, 
@@ -147,7 +165,13 @@
             "transcript_biotype": "retained_intron",
             "cdna_location": 
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
@@ -234,7 +258,13 @@
             "transcript_biotype": "nonsense_mediated_decay",
             "cdna_location": 
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
@@ -244,7 +274,13 @@
             },
             "cds_location": 
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 776, 
                 "end": 776, 
                 "length": 1, 
@@ -254,7 +290,13 @@
             },
             "protein_location":
             {
-                "relation": "overlaps" ,
+                "relation": {
+                    "accession_id": "variant_relation.overlaps",
+                    "label": "overlaps",
+                    "value": "overlaps",
+                    "definition": "The variant overlaps the feature",
+                    "description": ""
+                },
                 "start": 259, 
                 "end": 259, 
                 "length": 1, 

--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -49,7 +49,14 @@
             "prediction_results": [{   
                                         "score": 1  ,
                                         "result": null,
-                                        "classification": "tolerated",
+                                        "classification": 
+                                            {
+                                                "accession_id": "sift_prediction.tolerated",
+                                                "label": "tolerated",
+                                                "value": "tolerated",
+                                                "definition": "Value greater than or equal to 0.05",
+                                                "description": ""
+                                            },
                                         "analysis_method" : { 
                                                                 "tool": "SIFT"
                                                             }
@@ -58,7 +65,13 @@
                                           
                                         "score": 0  ,
                                         "result": null,
-                                        "classification": "benign",
+                                        "classification": {
+                                            "accession_id": "polyphen_prediction.benign",
+                                            "label": "benign",
+                                            "value": "benign",
+                                            "definition": "Value less than or equal to 0.446",
+                                            "description": ""
+                                        },
                                         "analysis_method" : { 
                                                                 "tool": "PolyPhen"
                                                             }
@@ -189,7 +202,14 @@
             "prediction_results": [{   
                                         "score": 1  ,
                                         "result": null,
-                                        "classification": "tolerated",
+                                        "classification": 
+                                            {
+                                                "accession_id": "sift_prediction.tolerated",
+                                                "label": "tolerated",
+                                                "value": "tolerated",
+                                                "definition": "Value greater than or equal to 0.05",
+                                                "description": ""
+                                            },
                                         "analysis_method" : { 
                                                                 "tool": "SIFT"
                                                             }
@@ -198,7 +218,13 @@
                                           
                                         "score": 0  ,
                                         "result": null,
-                                        "classification": "benign",
+                                        "classification": {
+                                            "accession_id": "polyphen_prediction.benign",
+                                            "label": "benign",
+                                            "value": "benign",
+                                            "definition": "less than or equal to 0.446",
+                                            "description": ""
+                                        },
                                         "analysis_method" : { 
                                                                 "tool": "PolyPhen"
                                                             }

--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -1,0 +1,240 @@
+{   
+    "name": "rs699",
+    "alleles":  [{
+        "name": "NC_000001.1:230710048:A:G",
+        "allele_type": 
+        {
+            "accession_id": "SO:0001483",
+            "value": "SNV",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0001483",
+            "source": {
+            "id": "...",
+            "name": "Sequence Ontology",
+            "url": "www.sequenceontology.org",
+            "description": "The Sequence Ontology..."
+            }
+        },
+        "predicted_molecular_consequences": 
+        [{
+            "allele_name": "G",
+            "feature_stable_id": "ENST00000680783",
+            "feature_type" : 
+            {
+            "accession_id": "SO:0000673",
+            "value": "transcript",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0000673",
+            "source": {
+                "id": "...",
+                "name": "Sequence Ontology",
+                "url": "www.sequenceontology.org",
+                "description": "The Sequence Ontology..."
+            }
+            },
+
+            "consequences":
+            [{
+            "accession_id": "SO:0001583",
+            "value": "missense_variant",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0001583",
+            "source": {
+                "id": "...",
+                "name": "Sequence Ontology",
+                "url": "www.sequenceontology.org",
+                "description": "The Sequence Ontology..."
+            }
+            }],
+            "gene_stable_id" : "ENSG00000135744",
+            "gene_symbol": "AGT",
+            "protein_stable_id": "ENSP00000506329",
+            "prediction_results": [{   
+                                        "score": 1  ,
+                                        "result": null,
+                                        "classification": "tolerated",
+                                        "analysis_method" : { 
+                                                                "tool": "SIFT"
+                                                            }
+                                    },
+                                    {
+                                          
+                                        "score": 0  ,
+                                        "result": null,
+                                        "classification": "benign",
+                                        "analysis_method" : { 
+                                                                "tool": "PolyPhen"
+                                                            }
+                                        
+                                    }
+                                ],
+            "feature_biotype": "protein_coding",
+            "cdna_location": 
+            {
+                "relation": "overlaps" ,
+                "start": 1287,
+                "end": 1287, 
+                "length": 1, 
+                "percentage_overlap": 1.0 ,
+                "sequence_change": "T/C" 
+            },
+            "cds_location": 
+            {
+                "relation": "overlaps" ,
+                "start": 776, 
+                "end": 776, 
+                "length": 1, 
+                "percentage_overlap": 1.0,
+                "sequence_change": "ATG/ACG"
+            },
+            "protein_location":
+            {
+                "relation": "overlaps" ,
+                "start": 259, 
+                "end": 259, 
+                "length": 1, 
+                "percentage_overlap": 1.0,
+                "sequence_change": "M/T"
+
+            }
+        },
+        {
+            "allele_name": "G",
+            "feature_stable_id": "ENST00000679854",
+            "feature_type" : 
+            {
+            "accession_id": "SO:0000673",
+            "value": "transcript",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0000673",
+            "source": {
+                "id": "...",
+                "name": "Sequence Ontology",
+                "url": "www.sequenceontology.org",
+                "description": "The Sequence Ontology..."
+            }
+            },
+
+            "consequences":
+            [{
+            "accession_id": "SO:0001583",
+            "value": "non_coding_transcript_exon_variant",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0001792",
+            "source": {
+                "id": "...",
+                "name": "Sequence Ontology",
+                "url": "www.sequenceontology.org",
+                "description": "The Sequence Ontology..."
+            }
+            }],
+            "gene_stable_id" : "ENSG00000135744",
+            "gene_symbol": "AGT",
+            "protein_stable_id": null,
+            "prediction_results": [] ,
+            "feature_biotype": "retained_intron",
+            "cdna_location": 
+            {
+                "relation": "overlaps" ,
+                "start": 1287,
+                "end": 1287, 
+                "length": 1, 
+                "percentage_overlap": 1.0 ,
+                "sequence_change": "T/C" 
+            }
+        },
+        {
+            "allele_name": "G",
+            "feature_stable_id": "ENST00000681772",
+            "feature_type" : 
+            {
+            "accession_id": "SO:0000673",
+            "value": "transcript",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0000673",
+            "source": {
+                "id": "...",
+                "name": "Sequence Ontology",
+                "url": "www.sequenceontology.org",
+                "description": "The Sequence Ontology..."
+            }
+            },
+
+            "consequences":
+            [{
+            "accession_id": "SO:0001583",
+            "value": "missense_variant&NMD_transcript_variant",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0001583",
+            "source": {
+                "id": "...",
+                "name": "Sequence Ontology",
+                "url": "www.sequenceontology.org",
+                "description": "The Sequence Ontology..."
+            }
+            }],
+            "gene_stable_id" : "ENSG00000135744",
+            "gene_symbol": "AGT",
+            "protein_stable_id": null,
+            "prediction_results": [{   
+                                        "score": 1  ,
+                                        "result": null,
+                                        "classification": "tolerated",
+                                        "analysis_method" : { 
+                                                                "tool": "SIFT"
+                                                            }
+                                    },
+                                    {
+                                          
+                                        "score": 0  ,
+                                        "result": null,
+                                        "classification": "benign",
+                                        "analysis_method" : { 
+                                                                "tool": "PolyPhen"
+                                                            }
+                                        
+                                    }
+                                ],
+            "feature_biotype": "nonsense_mediated_decay",
+            "cdna_location": 
+            {
+                "relation": "overlaps" ,
+                "start": 1287,
+                "end": 1287, 
+                "length": 1, 
+                "percentage_overlap": 1.0 ,
+                "sequence_change": "T/C" 
+            },
+            "cds_location": 
+            {
+                "relation": "overlaps" ,
+                "start": 776, 
+                "end": 776, 
+                "length": 1, 
+                "percentage_overlap": 1.0,
+                "sequence_change": "ATG/ACG"
+            },
+            "protein_location":
+            {
+                "relation": "overlaps" ,
+                "start": 259, 
+                "end": 259, 
+                "length": 1, 
+                "percentage_overlap": 1.0,
+                "sequence_change": "M/T"
+
+            }
+        }
+       ]
+    },
+    {
+        "name": "NC_000001.1:230710048:A:A",
+        "allele_type": 
+        {
+            "accession_id": "SO:0001411",
+            "value": "biological_region",
+            "url": "www.sequenceontology.org/browser/current_release/term/SO:0001411",
+            "source": {
+            "id": "...",
+            "name": "Sequence Ontology",
+            "url": "www.sequenceontology.org",
+            "description": "The Sequence Ontology..."
+            }
+        },  
+        "predicted_molecular_consequences": []
+    }
+]
+}

--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -17,7 +17,7 @@
         "predicted_molecular_consequences": 
         [{
             "allele_name": "G",
-            "feature_stable_id": "ENST00000680783",
+            "stable_id": "ENST00000680783",
             "feature_type" : 
             {
             "accession_id": "SO:0000673",
@@ -65,7 +65,7 @@
                                         
                                     }
                                 ],
-            "feature_biotype": "protein_coding",
+            "transcript_biotype": "protein_coding",
             "cdna_location": 
             {
                 "relation": "overlaps" ,
@@ -97,7 +97,7 @@
         },
         {
             "allele_name": "G",
-            "feature_stable_id": "ENST00000679854",
+            "stable_id": "ENST00000679854",
             "feature_type" : 
             {
             "accession_id": "SO:0000673",
@@ -113,7 +113,7 @@
 
             "consequences":
             [{
-            "accession_id": "SO:0001583",
+            "accession_id": "SO:0001792",
             "value": "non_coding_transcript_exon_variant",
             "url": "www.sequenceontology.org/browser/current_release/term/SO:0001792",
             "source": {
@@ -127,7 +127,7 @@
             "gene_symbol": "AGT",
             "protein_stable_id": null,
             "prediction_results": [] ,
-            "feature_biotype": "retained_intron",
+            "transcript_biotype": "retained_intron",
             "cdna_location": 
             {
                 "relation": "overlaps" ,
@@ -140,7 +140,7 @@
         },
         {
             "allele_name": "G",
-            "feature_stable_id": "ENST00000681772",
+            "stable_id": "ENST00000681772",
             "feature_type" : 
             {
             "accession_id": "SO:0000673",
@@ -157,7 +157,7 @@
             "consequences":
             [{
             "accession_id": "SO:0001583",
-            "value": "missense_variant&NMD_transcript_variant",
+            "value": "missense_variant",
             "url": "www.sequenceontology.org/browser/current_release/term/SO:0001583",
             "source": {
                 "id": "...",
@@ -165,7 +165,19 @@
                 "url": "www.sequenceontology.org",
                 "description": "The Sequence Ontology..."
             }
-            }],
+            },
+            {
+                "accession_id": "SO:0002114",
+                "value": "NMD_transcript_variant",
+                "url": "www.sequenceontology.org/browser/current_release/term/SO:0002114",
+                "source": {
+                    "id": "...",
+                    "name": "Sequence Ontology",
+                    "url": "www.sequenceontology.org",
+                    "description": "The Sequence Ontology..."
+                }
+            }
+            ],
             "gene_stable_id" : "ENSG00000135744",
             "gene_symbol": "AGT",
             "protein_stable_id": null,
@@ -188,7 +200,7 @@
                                         
                                     }
                                 ],
-            "feature_biotype": "nonsense_mediated_decay",
+            "transcript_biotype": "nonsense_mediated_decay",
             "cdna_location": 
             {
                 "relation": "overlaps" ,

--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -73,7 +73,9 @@
                 "end": 1287, 
                 "length": 1, 
                 "percentage_overlap": 100 ,
-                "sequence_change": "T/C" 
+                "ref_sequence": "T",
+                "alt_sequence": "C"
+
             },
             "cds_location": 
             {
@@ -82,7 +84,8 @@
                 "end": 776, 
                 "length": 1, 
                 "percentage_overlap": 100,
-                "sequence_change": "ATG/ACG"
+                "ref_sequence": "ATG",
+                "alt_sequence": "ACG"
             },
             "protein_location":
             {
@@ -91,7 +94,8 @@
                 "end": 259, 
                 "length": 1, 
                 "percentage_overlap": 100,
-                "sequence_change": "M/T"
+                "ref_sequence": "M",
+                "alt_sequence": "T"
 
             }
         },
@@ -135,7 +139,8 @@
                 "end": 1287, 
                 "length": 1, 
                 "percentage_overlap": 100 ,
-                "sequence_change": "T/C" 
+                "ref_sequence": "T",
+                "alt_sequence": "C"
             }
         },
         {
@@ -208,7 +213,8 @@
                 "end": 1287, 
                 "length": 1, 
                 "percentage_overlap": 100 ,
-                "sequence_change": "T/C" 
+                "ref_sequence": "T",
+                "alt_sequence": "C"
             },
             "cds_location": 
             {
@@ -217,7 +223,8 @@
                 "end": 776, 
                 "length": 1, 
                 "percentage_overlap": 100,
-                "sequence_change": "ATG/ACG"
+                "ref_sequence": "ATG",
+                "alt_sequence": "ACG"
             },
             "protein_location":
             {
@@ -226,7 +233,8 @@
                 "end": 259, 
                 "length": 1, 
                 "percentage_overlap": 100,
-                "sequence_change": "M/T"
+                "ref_sequence": "M",
+                "alt_sequence": "T"
 
             }
         }

--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -72,7 +72,7 @@
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
-                "percentage_overlap": 1.0 ,
+                "percentage_overlap": 100 ,
                 "sequence_change": "T/C" 
             },
             "cds_location": 
@@ -81,7 +81,7 @@
                 "start": 776, 
                 "end": 776, 
                 "length": 1, 
-                "percentage_overlap": 1.0,
+                "percentage_overlap": 100,
                 "sequence_change": "ATG/ACG"
             },
             "protein_location":
@@ -90,7 +90,7 @@
                 "start": 259, 
                 "end": 259, 
                 "length": 1, 
-                "percentage_overlap": 1.0,
+                "percentage_overlap": 100,
                 "sequence_change": "M/T"
 
             }
@@ -134,7 +134,7 @@
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
-                "percentage_overlap": 1.0 ,
+                "percentage_overlap": 100 ,
                 "sequence_change": "T/C" 
             }
         },
@@ -207,7 +207,7 @@
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
-                "percentage_overlap": 1.0 ,
+                "percentage_overlap": 100 ,
                 "sequence_change": "T/C" 
             },
             "cds_location": 
@@ -216,7 +216,7 @@
                 "start": 776, 
                 "end": 776, 
                 "length": 1, 
-                "percentage_overlap": 1.0,
+                "percentage_overlap": 100,
                 "sequence_change": "ATG/ACG"
             },
             "protein_location":
@@ -225,7 +225,7 @@
                 "start": 259, 
                 "end": 259, 
                 "length": 1, 
-                "percentage_overlap": 1.0,
+                "percentage_overlap": 100,
                 "sequence_change": "M/T"
 
             }

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -5,16 +5,17 @@ A set of information enabling interpretation of likely variant impact on genomic
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
 | allele_name           | string          | Data-derived allele name
-| feature_stable_id | string          | Feature (eg transcript) id
+| feature_stable_id | string          | Feature stable id (transcripts for now)
 | feature_type      | OntologyTermMetadata        | SO term for feature type (eg. transcript, regulatory feature)
 | consequences      | array of OntologyTermMetadata           | SO terms for predicted impact ( eg missense variants)
 | gene_stable_id | string| Gene stable id
 | gene_symbol | string | Gene symbol
+| protein_stable_id  | string or null | Protein stable id
 | variant_representation | array of VariantRepresentation or [ ]  | Nomenclature values and source
 | prediction_results | array of PredictionResult or [ ] | Scores from programs like SIFT which calculate transcript-specific deleteriousness scores
-| transcript_biotype | string |
-| cDNA_location | VariantRelativeLocation or null  | Relative location on cDNA
-| CDS_location | VariantRelativeLocation or null | Relative location on CDS
+| feature_biotype | string | Feature biotype
+| cdna_location | VariantRelativeLocation  | Relative location on cDNA
+| cds_location | VariantRelativeLocation or null | Relative location on CDS
 | protein_location | VariantRelativeLocation or null | Relative location on protein
 
 ```
@@ -22,7 +23,6 @@ A set of information enabling interpretation of likely variant impact on genomic
 
 "allele_name": "G",
 "feature_stable_id": "ENST00000680783",
-
 "feature_type" : 
 {
 "accession_id": "SO:0000673",
@@ -48,8 +48,9 @@ A set of information enabling interpretation of likely variant impact on genomic
     "description": "The Sequence Ontology..."
   }
 }],
-"gene_stable_id" : "ENSG00000135744" ,
-"gene_symbol": "AGT" ,
+"gene_stable_id" : "ENSG00000135744",
+"gene_symbol": "AGT",
+"protein_stable_id": "ENSP00000506329",
 "variant_representation": 
 {
 	"representation": "ENST00000680783.1:c.776T>C",
@@ -57,30 +58,33 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"qualifier": "coding"
 },
 "prediction_results": [] ,
-"transcript_biotype": "protein_coding",
-"cDNA_location": 
+"feature_biotype": "protein_coding",
+"cdna_location": 
 {
 	"relation": "overlaps" ,
-	"start": 1287, # gene end - transcript end - 1
-	"end": 1287, # gene end - transcript start  - 1
-	"length": 1, # relative end - relative start + 1
-	"percentage_overlap": 1.0, 
-}
-"CDS_location": 
+	"start": 1287,
+	"end": 1287, 
+	"length": 1, 
+	"percentage_overlap": 1.0,
+	"sequence_change": "T/C" 
+},
+"cds_location": 
 {
 	"relation": "overlaps" ,
-	"start": 776, # gene end - transcript end - 1
-	"end": 776, # gene end - transcript start  - 1
-	"length": 1, # relative end - relative start + 1
-	"percentage_overlap": 1.0, 
+	"start": 776, 
+	"end": 776, 
+	"length": 1, 
+	"percentage_overlap": 1.0,
+	"sequence_change": "ATG/ACG" 
 },
 "protein_location":
 {
 	"relation": "overlaps" ,
-	"start": 259, # gene end - transcript end - 1
-	"end": 259, # gene end - transcript start  - 1
-	"length": 1, # relative end - relative start + 1
-	"percentage_overlap": 1.0, 
+	"start": 259, 
+	"end": 259, 
+	"length": 1, 
+	"percentage_overlap": 1.0 ,
+	"sequence_change": "M/T" 
 }
 ```
 

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -5,7 +5,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
 | allele_name           | string          | Data-derived allele name
-| feature_stable_id | string          | Feature stable id (transcripts for now)
+| stable_id | string          | Feature stable id (transcripts for now)
 | feature_type      | OntologyTermMetadata        | SO term for feature type (eg. transcript, regulatory feature)
 | consequences      | array of OntologyTermMetadata           | SO terms for predicted impact ( eg missense variants)
 | gene_stable_id | string| Gene stable id
@@ -13,7 +13,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 | protein_stable_id  | string or null | Protein stable id
 | variant_representation | array of VariantRepresentation or [ ]  | Nomenclature values and source
 | prediction_results | array of PredictionResult or [ ] | Scores from programs like SIFT which calculate transcript-specific deleteriousness scores
-| feature_biotype | string | Feature biotype
+| transcript_biotype | string | Feature biotype
 | cdna_location | VariantRelativeLocation  | Relative location on cDNA
 | cds_location | VariantRelativeLocation or null | Relative location on CDS
 | protein_location | VariantRelativeLocation or null | Relative location on protein
@@ -22,7 +22,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 ## Example for rs699 
 
 "allele_name": "G",
-"feature_stable_id": "ENST00000680783",
+"transcript_stable_id": "ENST00000680783",
 "feature_type" : 
 {
 "accession_id": "SO:0000673",
@@ -58,7 +58,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"qualifier": "coding"
 },
 "prediction_results": [] ,
-"feature_biotype": "protein_coding",
+"transcript_biotype": "protein_coding",
 "cdna_location": 
 {
 	"relation": "overlaps" ,

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -66,7 +66,8 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"end": 1287, 
 	"length": 1, 
 	"percentage_overlap": 100,
-	"sequence_change": "T/C" 
+	"ref_sequence": "T",
+	"alt_sequence": "C" 
 },
 "cds_location": 
 {
@@ -75,7 +76,8 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"end": 776, 
 	"length": 1, 
 	"percentage_overlap": 100,
-	"sequence_change": "ATG/ACG" 
+	"ref_sequence": "ATG",
+	"alt_sequence":   "ACG" 
 },
 "protein_location":
 {
@@ -84,7 +86,8 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"end": 259, 
 	"length": 1, 
 	"percentage_overlap": 100 ,
-	"sequence_change": "M/T" 
+	"ref_sequence": "M",
+	"alt_sequence": "T" 
 }
 ```
 

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -17,6 +17,73 @@ A set of information enabling interpretation of likely variant impact on genomic
 | CDS_location | VariantRelativeLocation or null | Relative location on CDS
 | protein_location | VariantRelativeLocation or null | Relative location on protein
 
+```
+## Example for rs699 
+
+"allele_name": "G",
+"feature_stable_id": "ENST00000680783",
+
+"feature_type" : 
+{
+"accession_id": "SO:0000673",
+"value": "transcript",
+"url": "www.sequenceontology.org/browser/current_release/term/SO:0000673",
+  "source": {
+    "id": "...",
+    "name": "Sequence Ontology",
+    "url": "www.sequenceontology.org",
+    "description": "The Sequence Ontology..."
+  }
+},
+
+"consequences":
+[{
+  "accession_id": "SO:0001583",
+  "value": "missense_variant",
+  "url": "www.sequenceontology.org/browser/current_release/term/SO:0001583",
+  "source": {
+    "id": "...",
+    "name": "Sequence Ontology",
+    "url": "www.sequenceontology.org",
+    "description": "The Sequence Ontology..."
+  }
+}],
+"gene_stable_id" : "ENSG00000135744" ,
+"gene_symbol": "AGT" ,
+"variant_representation": 
+{
+	"representation": "ENST00000680783.1:c.776T>C",
+	"naming convention": "HGVS",
+	"qualifier": "coding"
+},
+"prediction_results": [] ,
+"transcript_biotype": "protein_coding",
+"cDNA_location": 
+{
+	"relation": "overlaps" ,
+	"start": 1287, # gene end - transcript end - 1
+	"end": 1287, # gene end - transcript start  - 1
+	"length": 1, # relative end - relative start + 1
+	"percentage_overlap": 1.0, 
+}
+"CDS_location": 
+{
+	"relation": "overlaps" ,
+	"start": 776, # gene end - transcript end - 1
+	"end": 776, # gene end - transcript start  - 1
+	"length": 1, # relative end - relative start + 1
+	"percentage_overlap": 1.0, 
+},
+"protein_location":
+{
+	"relation": "overlaps" ,
+	"start": 259, # gene end - transcript end - 1
+	"end": 259, # gene end - transcript start  - 1
+	"length": 1, # relative end - relative start + 1
+	"percentage_overlap": 1.0, 
+}
+```
+
 
 
 

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -65,7 +65,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"start": 1287,
 	"end": 1287, 
 	"length": 1, 
-	"percentage_overlap": 1.0,
+	"percentage_overlap": 100,
 	"sequence_change": "T/C" 
 },
 "cds_location": 
@@ -74,7 +74,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"start": 776, 
 	"end": 776, 
 	"length": 1, 
-	"percentage_overlap": 1.0,
+	"percentage_overlap": 100,
 	"sequence_change": "ATG/ACG" 
 },
 "protein_location":
@@ -83,7 +83,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 	"start": 259, 
 	"end": 259, 
 	"length": 1, 
-	"percentage_overlap": 1.0 ,
+	"percentage_overlap": 100 ,
 	"sequence_change": "M/T" 
 }
 ```

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -8,9 +8,14 @@ A set of information enabling interpretation of likely variant impact on genomic
 | feature_stable_id | string          | Feature (eg transcript) id
 | feature_type      | OntologyTermMetadata        | SO term for feature type (eg. transcript, regulatory feature)
 | consequences      | array of OntologyTermMetadata           | SO terms for predicted impact ( eg missense variants)
-| variant_representation            | array of VariantRepresentation or [ ]  | Nomenclature values and source
+| gene_stable_id | string| Gene stable id
+| gene_symbol | string | Gene symbol
+| variant_representation | array of VariantRepresentation or [ ]  | Nomenclature values and source
 | prediction_results | array of PredictionResult or [ ] | Scores from programs like SIFT which calculate transcript-specific deleteriousness scores
-| relative_locations | array of VariantRelativeLocation  | 
+| transcript_biotype | string |
+| cDNA_location | VariantRelativeLocation or null  | Relative location on cDNA
+| CDS_location | VariantRelativeLocation or null | Relative location on CDS
+| protein_location | VariantRelativeLocation or null | Relative location on protein
 
 
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -4,7 +4,6 @@ It is important to know where in a genomic feature a variant lies and in the cas
 
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
-| object            | Feature          | A reference feature sequence the subject overlaps eg. a transcript
 | relation          | ValueSet        | Type of relative location 
 | start             | int             | Start of subject within object. May be negative if upstream 
 | end               | int             | End of subject within object 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -13,7 +13,9 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | alt_sequence   | string          | New sequence 
 
 
-Note: For `alt_sequence`, in case of frameshift variants, "X" would be easier to handle than any of the other options for now. In the future, we replace "X" with the new protein string.
+Note: 
+For `alt_sequence`, in case of frameshift variants, "X" would be easier to handle than any of the other options for now. In the future, we replace "X" with the new protein string.
+In case of deletion, `alt_sequence` will be "-" 
 
 
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -9,7 +9,7 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | end               | int             | End of subject within object 
 | length            | int             | Length of overlap
 | percentage_overlap| float           | Percentage of object overlapped by the subject (Of particular interest for structural variants)
-| sequence_change   | string          | Sequence change based on the genomic feature
+| sequence_change   | string          | Sequence change based on the overlapping feature
 
 
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -9,11 +9,11 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | end               | int             | End of subject within object 
 | length            | int             | Length of overlap
 | percentage_overlap| float           | Percentage of object overlapped by the subject (Of particular interest for structural variants)
-| sequence_change   | string          | Sequence change based on the overlapping feature
+| ref_sequence   | string          | Original sequence 
+| alt_sequence   | string          | New sequence 
 
 
-
-
+Note: For `alt_sequence`, in case of frameshift variants, "X" would be easier to handle than any of the other options for now. In the future, we replace "X" with the new protein string.
 
 
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -9,6 +9,7 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | end               | int             | End of subject within object 
 | length            | int             | Length of overlap
 | percentage_overlap| float           | Percentage of object overlapped by the subject (Of particular interest for structural variants)
+| sequence_change   | string          | Sequence change based on the genomic feature
 
 
 

--- a/src/docs/variant_representation.md
+++ b/src/docs/variant_representation.md
@@ -3,7 +3,7 @@
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
 | representation    | string          | Representation/ name of the variant under the stated convention eg: ENST00000366667.6:c.776T>C
-| naming convention | string          | Name of naming format, eg, HGVS, SPDI 
+| naming_convention | string          | Name of naming format, eg, HGVS, SPDI 
 | qualifier         | ValueSet or null| Eg: For HGVS these will be ‘ coding’, ‘non-coding’ ‘protein’, ‘genomic’ etc
 
 


### PR DESCRIPTION
[ENSVAR-6168](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6168)

- [x] Relevant examples
- [x] Add protein_id
- [x] Feature stable ID - > Stable ID (just doing for transcript)
- [x] Biotype as string is fine.
- [x] cDNA location is not nullable
- [x] Sequence change added to variant_relative_location to capture sequence change of the overlapping feature
- [x] Example json for rs699