### PR TITLE
Updates to predicted_molecular_consequence

### DIFF
--- a/examples/predicted_molecular_consequences/rs699.json
+++ b/examples/predicted_molecular_consequences/rs699.json
@@ -81,50 +81,26 @@
             "transcript_biotype": "protein_coding",
             "cdna_location": 
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
-                "percentage_overlap": 100 ,
                 "ref_sequence": "T",
                 "alt_sequence": "C"
 
             },
             "cds_location": 
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 776, 
                 "end": 776, 
                 "length": 1, 
-                "percentage_overlap": 100,
                 "ref_sequence": "ATG",
                 "alt_sequence": "ACG"
             },
             "protein_location":
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 259, 
                 "end": 259, 
                 "length": 1, 
-                "percentage_overlap": 100,
                 "ref_sequence": "M",
                 "alt_sequence": "T"
 
@@ -165,17 +141,9 @@
             "transcript_biotype": "retained_intron",
             "cdna_location": 
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
-                "percentage_overlap": 100 ,
                 "ref_sequence": "T",
                 "alt_sequence": "C"
             }
@@ -258,49 +226,25 @@
             "transcript_biotype": "nonsense_mediated_decay",
             "cdna_location": 
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 1287,
                 "end": 1287, 
                 "length": 1, 
-                "percentage_overlap": 100 ,
                 "ref_sequence": "T",
                 "alt_sequence": "C"
             },
             "cds_location": 
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 776, 
                 "end": 776, 
                 "length": 1, 
-                "percentage_overlap": 100,
                 "ref_sequence": "ATG",
                 "alt_sequence": "ACG"
             },
             "protein_location":
             {
-                "relation": {
-                    "accession_id": "variant_relation.overlaps",
-                    "label": "overlaps",
-                    "value": "overlaps",
-                    "definition": "The variant overlaps the feature",
-                    "description": ""
-                },
                 "start": 259, 
                 "end": 259, 
                 "length": 1, 
-                "percentage_overlap": 100,
                 "ref_sequence": "M",
                 "alt_sequence": "T"
 

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -61,31 +61,25 @@ A set of information enabling interpretation of likely variant impact on genomic
 "transcript_biotype": "protein_coding",
 "cdna_location": 
 {
-	"relation": "overlaps" ,
 	"start": 1287,
 	"end": 1287, 
 	"length": 1, 
-	"percentage_overlap": 100,
 	"ref_sequence": "T",
 	"alt_sequence": "C" 
 },
 "cds_location": 
 {
-	"relation": "overlaps" ,
 	"start": 776, 
 	"end": 776, 
 	"length": 1, 
-	"percentage_overlap": 100,
 	"ref_sequence": "ATG",
 	"alt_sequence":   "ACG" 
 },
 "protein_location":
 {
-	"relation": "overlaps" ,
 	"start": 259, 
 	"end": 259, 
 	"length": 1, 
-	"percentage_overlap": 100 ,
 	"ref_sequence": "M",
 	"alt_sequence": "T" 
 }

--- a/src/docs/predicted_molecular_consequence.md
+++ b/src/docs/predicted_molecular_consequence.md
@@ -14,7 +14,7 @@ A set of information enabling interpretation of likely variant impact on genomic
 | variant_representation | array of VariantRepresentation or [ ]  | Nomenclature values and source
 | prediction_results | array of PredictionResult or [ ] | Scores from programs like SIFT which calculate transcript-specific deleteriousness scores
 | transcript_biotype | string | Feature biotype
-| cdna_location | VariantRelativeLocation  | Relative location on cDNA
+| cdna_location | VariantRelativeLocation or null  | Relative location on cDNA
 | cds_location | VariantRelativeLocation or null | Relative location on CDS
 | protein_location | VariantRelativeLocation or null | Relative location on protein
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -4,11 +4,11 @@ It is important to know where in a genomic feature a variant lies and in the cas
 
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
-| relation          | ValueSet        | Type of relative location 
+| relation          | ValueSet or null        | Type of relative location 
 | start             | int             | Start of subject within object. May be negative if upstream 
 | end               | int             | End of subject within object 
 | length            | int             | Length of overlap
-| percentage_overlap| float           | Percentage of object overlapped by the subject (Of particular interest for structural variants)
+| percentage_overlap| float or null         | Percentage of object overlapped by the subject (Of particular interest for structural variants)
 | ref_sequence   | string          | Original sequence 
 | alt_sequence   | string          | New sequence 
 


### PR DESCRIPTION
1. `predicted_molecular_consequence->cdna_location` can be null for intron variant, so it needs to be a nullable field. Eg: http://jul2023.archive.ensembl.org/Homo_sapiens/Variation/Mappings?db=core;r=21:45987948-45988947;v=rs1312342906;vdb=variation;vf=271881848
2. `variant_relative_location->relation` and `variant_relative_location->percentage_overlap` are not relevant for non-SVs, so making them nullable 