### PR TITLE
Variant relative location modified for unknown boundaries

### DIFF
--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -5,9 +5,9 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
 | relation          | ValueSet or null        | Type of relative location 
-| start             | string             | Start of subject within object. May be "?" if intronic
-| end               | string             | End of subject within object.  
-| length            | int             | Length of overlap. May be negative if boundary is not known
+| start             | int or null             | Start of subject within object. May be "?" if intronic
+| end               | int or null             | End of subject within object.  
+| length            | int  or null          | Length of overlap. May be negative if boundary is not known
 | percentage_overlap| float or null         | Percentage of object overlapped by the subject (Of particular interest for structural variants)
 | ref_sequence   | string or null          | Original sequence 
 | alt_sequence   | string  or null        | New sequence 
@@ -19,9 +19,9 @@ In case of deletion, `alt_sequence` will be "-"
 
 In the case of variants with unknown start/end locations:
 For example, "628-?",  
-`start`: "628"
-`end`: "?"
-`length`: -1
+`start`: 628
+`end`: null
+`length`: null
 `ref_sequence`: null
 `alt_sequence`: null
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -5,17 +5,25 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
 | relation          | ValueSet or null        | Type of relative location 
-| start             | int             | Start of subject within object. May be negative if upstream 
-| end               | int             | End of subject within object 
-| length            | int             | Length of overlap
+| start             | string             | Start of subject within object. May be "?" if intronic
+| end               | string             | End of subject within object.  
+| length            | int             | Length of overlap. May be negative if boundary is not known
 | percentage_overlap| float or null         | Percentage of object overlapped by the subject (Of particular interest for structural variants)
-| ref_sequence   | string          | Original sequence 
-| alt_sequence   | string          | New sequence 
+| ref_sequence   | string or null          | Original sequence 
+| alt_sequence   | string  or null        | New sequence 
 
 
 Note: 
 For `alt_sequence`, in case of frameshift variants, "X" would be easier to handle than any of the other options for now. In the future, we replace "X" with the new protein string.
 In case of deletion, `alt_sequence` will be "-" 
+
+In the case of variants with unknown start/end locations:
+For example, "628-?",  
+`start`: "628"
+`end`: "?"
+`length`: -1
+`ref_sequence`: null
+`alt_sequence`: null
 
 
 

--- a/src/docs/variant_relative_location.md
+++ b/src/docs/variant_relative_location.md
@@ -5,9 +5,9 @@ It is important to know where in a genomic feature a variant lies and in the cas
 | Field             | Type            | Description
 |-------------------|-----------------|---------------------
 | relation          | ValueSet or null        | Type of relative location 
-| start             | int or null             | Start of subject within object. May be "?" if intronic
+| start             | int or null             | Start of subject within object. May be null if intronic
 | end               | int or null             | End of subject within object.  
-| length            | int  or null          | Length of overlap. May be negative if boundary is not known
+| length            | int  or null          | Length of overlap. May be null if boundary is not known
 | percentage_overlap| float or null         | Percentage of object overlapped by the subject (Of particular interest for structural variants)
 | ref_sequence   | string or null          | Original sequence 
 | alt_sequence   | string  or null        | New sequence 


### PR DESCRIPTION
It is possible to have variant relative locations with unknown start/end locations:

For example, cdna location with `628-?`,  the proposal is to return
`start`: 628
`end`: null
`length`: null
`ref_sequence`: null
`alt_sequence`: null

### Changes in VDM
`variant_relative_location`->`start` can be null
`variant_relative_location`->`end` can be null
`variant_relative_location`->`length` can be null
`variant_relative_location`->`ref_sequence` can be null
`variant_relative_location`->`alt_sequence` can be null
